### PR TITLE
Check for tx has already been created

### DIFF
--- a/src/state/dbOperations/transactionOperations.ts
+++ b/src/state/dbOperations/transactionOperations.ts
@@ -32,13 +32,15 @@ export class TransactionOperations extends DbOperations {
     return transaction;
   }
 
-  public async hasTransactionWithGTETimestamp(timestamp: Timestamp): Promise<boolean> {
+  public async hasTransactionWithTimestamp(timestamp: Timestamp, filter: "gte" | "gt"): Promise<boolean> {
     const transaction = await this.tx.transaction.findFirst({
       where: {
-        time: { gte: new Date(timestamp.epochMs) }
+        time: filter == "gte" ? { gte: new Date(timestamp.epochMs) } : { gt: new Date(timestamp.epochMs) }
       }
     });
     return transaction !== null;
   }
+
+
 
 }

--- a/src/state/dbOperations/transactionOperations.ts
+++ b/src/state/dbOperations/transactionOperations.ts
@@ -32,10 +32,10 @@ export class TransactionOperations extends DbOperations {
     return transaction;
   }
 
-  public async hasTransactionWithHigherTimestamp(timestamp: Timestamp): Promise<boolean> {
+  public async hasTransactionWithGTETimestamp(timestamp: Timestamp): Promise<boolean> {
     const transaction = await this.tx.transaction.findFirst({
       where: {
-        time: { gt: new Date(timestamp.epochMs) }
+        time: { gte: new Date(timestamp.epochMs) }
       }
     });
     return transaction !== null;

--- a/src/state/handlers/stratsHandler/kandelEventHandler.ts
+++ b/src/state/handlers/stratsHandler/kandelEventHandler.ts
@@ -102,10 +102,12 @@ const eventMatcher =
 async function waitForTimestamp(allDbOperation: AllDbOperations, timestamp:Timestamp) {
   let isReady = false;
   while (!isReady) {
-    isReady = await allDbOperation.transactionOperations.hasTransactionWithGTETimestamp(timestamp);
-    if (!isReady) {
-      await sleep(5000);
+    isReady = await allDbOperation.transactionOperations.hasTransactionWithTimestamp(timestamp, "gt");
+    if (isReady) {
+      break;
     }
+    isReady = await allDbOperation.transactionOperations.hasTransactionWithTimestamp(timestamp, "gte");
+    await sleep(5000);
   }
 }
 

--- a/src/state/handlers/stratsHandler/kandelEventHandler.ts
+++ b/src/state/handlers/stratsHandler/kandelEventHandler.ts
@@ -93,9 +93,9 @@ const eventMatcher =
 async function waitForTimestamp(allDbOperation: AllDbOperations, timestamp:Timestamp) {
   let isReady = false;
   while (!isReady) {
-    isReady = await allDbOperation.transactionOperations.hasTransactionWithHigherTimestamp(timestamp);
+    isReady = await allDbOperation.transactionOperations.hasTransactionWithGTETimestamp(timestamp);
     if (!isReady) {
-      await sleep(1000);
+      await sleep(5000);
     }
   }
 }

--- a/src/state/handlers/stratsHandler/kandelEventsLogic.ts
+++ b/src/state/handlers/stratsHandler/kandelEventsLogic.ts
@@ -31,7 +31,8 @@ export class KandelEventsLogic extends EventsLogic {
         const reserveId = new AccountId(mangroveId.chainId,  event.reserveId == "" || !event.reserveId ? event.kandel : event.reserveId);
         await this.db.accountOperations.ensureAccount(reserveId);
         const newConfiguration = await this.db.kandelOperations.createNewKandelConfiguration(this.mapSetParamsToKandelConfiguration(event.params));
-        const adminId = new AccountId(mangroveId.chainId, event.owner).value;
+        const adminId = new AccountId(mangroveId.chainId, event.owner);
+        await this.db.accountOperations.ensureAccount(adminId);
         const baseToken = new TokenId(mangroveId.chainId, event.base);
         const quoteToken = new TokenId(mangroveId.chainId, event.quote);
 
@@ -40,7 +41,7 @@ export class KandelEventsLogic extends EventsLogic {
             txId: transaction!.id,
             updateFunc: (model) => {
                 _.merge(model, {
-                    adminId: adminId,
+                    adminId: adminId.value,
                     routerAddress: event.params.router,
                     congigurationId: newConfiguration.id,
                 });


### PR DESCRIPTION
This ensures that a tx with a larger or equal timestamp, has already been created by another stream. This lowers the risk of kandel trying to read references to stuff that has not yet been created.