### PR TITLE
fix: unable to delete when reorg happens

### DIFF
--- a/prisma/migrations/20230526103337_revese_fills_relation/migration.sql
+++ b/prisma/migrations/20230526103337_revese_fills_relation/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "Order_id_idx" ON "Order"("id");
+
+-- CreateIndex
+CREATE INDEX "TakenOffer_id_idx" ON "TakenOffer"("id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -465,13 +465,14 @@ model Order {
   childTakerApprovalVersions TakerApprovalVersion[]
   childOfferVersions         OfferVersion[]
   MangroveOrder              MangroveOrder[]
-  MangroveOrderFill          MangroveOrderFill[]
+  MangroveOrderFill          MangroveOrderFill      @relation(fields: [id], references: [fillsId])
 
   @@index([txId])
   @@index([parentOrderId])
   @@index([mangroveId])
   @@index([offerListingId])
   @@index([takerId])
+  @@index([id])
 }
 
 model TakenOffer {
@@ -492,10 +493,11 @@ model TakenOffer {
   order             Order               @relation(fields: [orderId], references: [id], onDelete: Cascade)
   offerVersion      OfferVersion        @relation(fields: [offerVersionId], references: [id], onDelete: Cascade)
   TokenBalanceEvent TokenBalanceEvent[]
-  MangroveOrderFill MangroveOrderFill[]
+  MangroveOrderFill MangroveOrderFill?   @relation(fields: [id], references: [fillsId])
 
   @@unique([orderId, offerVersionId])
   @@index([offerVersionId])
+  @@index([id])
 }
 
 model MangroveOrder {
@@ -865,7 +867,7 @@ view MangroveOrderFill {
   takerId         String
   offerListingId  String
   mangroveOrderId String?
-  fillsId         String
+  fillsId         String   @unique
   type            String
   totalFee        Float
   takerGot        Float
@@ -876,8 +878,8 @@ view MangroveOrderFill {
   time            DateTime @db.Timestamp
 
   offerListing OfferListing @relation(fields: [offerListingId], references: [id])
-  order        Order?       @relation(fields: [fillsId], references: [id])
-  takenOffer   TakenOffer?  @relation(fields: [fillsId], references: [id])
+  Order        Order[]
+  TakenOffer   TakenOffer[]
 
   @@unique([type, fillsId])
   @@index([takerId])

--- a/src/resolvers/customFieldResolvers.ts
+++ b/src/resolvers/customFieldResolvers.ts
@@ -319,15 +319,19 @@ export class MangroveOrderResolver {
       },
       include: {
         offerListing: { include: { inboundToken: true, outboundToken: true } },
-        order: true,
-        takenOffer: true
+        Order: {
+          take: 1
+        },
+        TakenOffer: {
+          take: 1
+        }
       },
       orderBy: { time: 'desc' },
       take, skip
     });
 
     return fills.map(m => {
-      const hasTakenOffer = m.takenOffer != null;
+      const hasTakenOffer = m.TakenOffer.length > 0;
       const fillsAmount = this.getFillsAmount(m.offerListing.outboundToken.address, token2, m.takerGot, m.takerGave, hasTakenOffer) ?? 0;
       const paid = this.getFillsPaid(m.offerListing.outboundToken.address, token2, m.takerGot, m.takerGave, hasTakenOffer) ?? 0;
       return new MangroveOrderFillWithTokens({

--- a/src/state/dbOperations/kandelOperations.ts
+++ b/src/state/dbOperations/kandelOperations.ts
@@ -374,7 +374,7 @@ export class KandelOperations extends DbOperations {
     if( !offerVersion) {
       const retractEvent = await this.tx.kandelRetractEvent.findUnique({where: { id:id}});
       if( !retractEvent) {
-        throw new Error( `Cannot fund retract event to delete: id: ${id}`)
+        throw new Error( `Cannot find retract event to delete: id: ${id}`)
       }
       await this.tx.kandelEvent.delete({where: { id: retractEvent?.eventId}});
     }
@@ -385,7 +385,7 @@ export class KandelOperations extends DbOperations {
     if( !offerVersion) {
       const populateEvent = await this.tx.kandelPopulateEvent.findUnique({where: { id:id}});
       if( !populateEvent) {
-        throw new Error( `Cannot fund populate event to delete: id: ${id}`)
+        throw new Error( `Cannot find populate event to delete: id: ${id}`)
       }
       await this.tx.kandelEvent.delete({where: { id: populateEvent?.eventId}});
     }

--- a/src/state/dbOperations/offerOperations.ts
+++ b/src/state/dbOperations/offerOperations.ts
@@ -119,11 +119,11 @@ export class OfferOperations extends DbOperations {
     if (version === null) throw Error(`OfferVersion not found - id: ${id.value}, currentVersionId: ${offer.currentVersionId}`);
 
     if( version.OfferWriteEvent){
-      await this.tx.offerWriteEvent.delete({ where: { id: version.OfferWriteEvent.id } });
+      await this.tx.mangroveEvent.delete({ where: { id: version.OfferWriteEvent.mangroveEventId } });
     }
 
     if( version.OfferRetractEvent){
-      await this.tx.offerRetractEvent.delete({ where: { id: version.OfferRetractEvent.id } });
+      await this.tx.mangroveEvent.delete({ where: { id: version.OfferRetractEvent.mangroveEventId } });
     }
 
 

--- a/src/state/dbOperations/offerOperations.ts
+++ b/src/state/dbOperations/offerOperations.ts
@@ -112,13 +112,20 @@ export class OfferOperations extends DbOperations {
   }
 
   public async deleteLatestOfferVersion(id: OfferId) {
-    const offer = await this.tx.offer.findUnique({ where: { id: id.value } });
+    const offer = await this.tx.offer.findUnique({ where: { id: id.value }, include: { currentVersion: { include: { OfferWriteEvent: true, OfferRetractEvent:  true}} } });
     if (offer === null) throw Error(`Offer not found - id: ${id.value}`);
 
-    const version = await this.tx.offerVersion.findUnique({
-      where: { id: offer.currentVersionId },
-    });
+    const version = offer.currentVersion;
     if (version === null) throw Error(`OfferVersion not found - id: ${id.value}, currentVersionId: ${offer.currentVersionId}`);
+
+    if( version.OfferWriteEvent){
+      await this.tx.offerWriteEvent.delete({ where: { id: version.OfferWriteEvent.id } });
+    }
+
+    if( version.OfferRetractEvent){
+      await this.tx.offerRetractEvent.delete({ where: { id: version.OfferRetractEvent.id } });
+    }
+
 
     
     if (version.prevVersionId === null) {

--- a/test/integration/state/dbOperations/offerOperations.integration.test.ts
+++ b/test/integration/state/dbOperations/offerOperations.integration.test.ts
@@ -235,12 +235,14 @@ describe("Offer Operations Integration test suite", () => {
           offerVersionId: offerVersion.id,
           offerListingId: offerListingId.value,
           mangroveEventId: mangroveEvent.id,
+          deprovision: false,
         }
       })
       await offerOperations.deleteLatestOfferVersion(offerId);
       assert.strictEqual(await prisma.offer.count(), 1);
       assert.strictEqual(await prisma.offerVersion.count(), 1);
       assert.strictEqual(await prisma.offerRetractEvent.count(), 0);
+      assert.strictEqual(await prisma.mangroveEvent.count(), 0);
       const offer = await prisma.offer.findUnique({where: { id: offerId.value}});
       assert.strictEqual(offer?.currentVersionId, offerVersionId.value);
     });

--- a/test/integration/state/dbOperations/offerOperations.integration.test.ts
+++ b/test/integration/state/dbOperations/offerOperations.integration.test.ts
@@ -194,6 +194,59 @@ describe("Offer Operations Integration test suite", () => {
       await assert.rejects( offerOperations.deleteLatestOfferVersion(offerId));
     } );
 
+    it("Has offerWriteEvent relation, delete offerVersion", async () => {
+      const offerVersion = await offerOperations.addVersionedOffer(offerId, "txId", (o) => o.gasreq=10);
+      const mangroveEvent = await prisma.mangroveEvent.create({
+        data: {
+          mangroveId: mangroveId.value,
+          txId: "txId",
+        }})
+      
+      await prisma.offerWriteEvent.create({
+        data: {
+          offerVersionId: offerVersion.id,
+          offerListingId:offerListingId.value,
+          makerId: makerId.value,
+          mangroveEventId: mangroveEvent.id,
+          wants: "0",
+          gives: "0",
+          gasprice: 0,
+          gasreq: 10,
+          prev: 0
+        }
+      })
+      await offerOperations.deleteLatestOfferVersion(offerId);
+      assert.strictEqual(await prisma.offer.count(), 1);
+      assert.strictEqual(await prisma.offerVersion.count(), 1);
+      assert.strictEqual(await prisma.offerWriteEvent.count(), 0);
+      const offer = await prisma.offer.findUnique({where: { id: offerId.value}});
+      assert.strictEqual(offer?.currentVersionId, offerVersionId.value);
+    })
+
+    it("Has offerRetractEvent relation, delete offerVersion", async () => {
+      const offerVersion = await offerOperations.addVersionedOffer(offerId, "txId", (o) => o.gasreq=10);
+      const mangroveEvent = await prisma.mangroveEvent.create({
+        data: {
+          mangroveId: mangroveId.value,
+          txId: "txId",
+        }})
+      await prisma.offerRetractEvent.create({
+        data: {
+          offerVersionId: offerVersion.id,
+          offerListingId: offerListingId.value,
+          mangroveEventId: mangroveEvent.id,
+        }
+      })
+      await offerOperations.deleteLatestOfferVersion(offerId);
+      assert.strictEqual(await prisma.offer.count(), 1);
+      assert.strictEqual(await prisma.offerVersion.count(), 1);
+      assert.strictEqual(await prisma.offerRetractEvent.count(), 0);
+      const offer = await prisma.offer.findUnique({where: { id: offerId.value}});
+      assert.strictEqual(offer?.currentVersionId, offerVersionId.value);
+    });
+
+            
+
     it("No prevVersion, delete both offer and offerVersion", async () => {
       assert.strictEqual(await prisma.offer.count(), 1);
       assert.strictEqual(await prisma.offerVersion.count(), 1);

--- a/test/integration/state/dbOperations/orderOperations.integration.test.ts
+++ b/test/integration/state/dbOperations/orderOperations.integration.test.ts
@@ -46,6 +46,16 @@ describe("Order Operations Integration test Suite", () => {
 
     beforeEach(async () => {
 
+        await prisma.transaction.create({
+            data: {
+                id: "txId",
+                blockNumber: 1,
+                blockHash: "blockHash",
+                time: new Date(),
+                txHash: "txHash",
+                from: "from",
+            }})
+
         await prisma.token.create({
             data: {
                 id: inboundTokenId.value,


### PR DESCRIPTION
This fixes the issue
+ Where we are trying to delete an order or a taken offer, because of a reorg. This was not possible because of a relation from the view table MangroveOrderFill to Order/TakenOffer. The relation has been inverted, meaning Order and TakenOffer now have a relation to the MangroveOrderFill view table. This enables the delete of TakenOffer and Order.

+ Unable to delete offerVersion, because the table OfferWriteEvent, still had a reference to the offerVersion. Fixed by deleting the offerWriteEvent first